### PR TITLE
R2ModMan Fix

### DIFF
--- a/PackageLoader.cs
+++ b/PackageLoader.cs
@@ -34,7 +34,23 @@ namespace ExtraItems
         }
         private void LoadMainPackage()
         {
-            ExtraItemsBundle = AssetBundle.LoadFromFile(Utility.CombinePaths(PackagePath, "extraitemsbundle"));
+           try
+	            {
+		    this.ExtraItemsBundle = AssetBundle.LoadFromFile(Utility.CombinePaths(new string[]
+		    {
+			    this.PackagePath,
+			    "Toedtmanns-ExtraItems",
+			    "extraitemsbundle"
+		    }));
+	            }    
+	catch (Exception)
+	{
+		this.ExtraItemsBundle = AssetBundle.LoadFromFile(Utility.CombinePaths(new string[]
+		{
+			this.PackagePath,
+			"extraitemsbundle"
+		}));
+	}
         }
     }
 }


### PR DESCRIPTION
When downloading this mod through r2modman, it fails to put the assetbundle in the correct folder. This PR patches it so it checks both locations, one for r2modman, and one for a standalone download.